### PR TITLE
set this_script var before returning

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -29,12 +29,12 @@ if(_CMRC_GENERATE_MODE)
     return()
 endif()
 
+set(this_script "${CMAKE_CURRENT_LIST_FILE}")
+
 if(COMMAND cmrc_add_resource_library)
     # CMakeRC has already been included! Don't do anything
     return()
 endif()
-
-set(this_script "${CMAKE_CURRENT_LIST_FILE}")
 
 # CMakeRC uses std::call_once().
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)


### PR DESCRIPTION
In case the CMakeRC.cmake is included multiple times, this_script is not set in subsequent calls and the function _cmrc_generate_intermediate_cpp needs it..